### PR TITLE
GET work on protected route with JWY

### DIFF
--- a/config/packages/lexik_jwt_authentication.yaml
+++ b/config/packages/lexik_jwt_authentication.yaml
@@ -2,3 +2,4 @@ lexik_jwt_authentication:
     secret_key: '%env(resolve:JWT_SECRET_KEY)%'
     public_key: '%env(resolve:JWT_PUBLIC_KEY)%'
     pass_phrase: '%env(JWT_PASSPHRASE)%'
+    user_identity_field: email

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -41,7 +41,7 @@ security:
   # Note: Only the *first* access control that matches will be used
   access_control:
     - { path: ^/api/login, roles: PUBLIC_ACCESS }
-      # - { path: ^/api,       roles: IS_AUTHENTICATED_FULLY }
+    - { path: ^/api,       roles: IS_AUTHENTICATED_FULLY }
       # - { path: ^/admin, roles: ROLE_ADMIN }
       # - { path: ^/profile, roles: ROLE_USER }
 


### PR DESCRIPTION
adding the ```user_identity_field: email``` line in ```config/packages/lexik_jwt_authentication.yaml``` for enable JWT to test the token with the user's mail (by default user's username is used)